### PR TITLE
Improve Filterable

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,11 +1,5 @@
 class UsersController < ApplicationController
   def index
-    @users = User.filter_by(filtering_params).page(params[:page])
-  end
-
-  private
-
-  def filtering_params
-    params.slice(*User.filter_scopes)
+    @users = User.filter_by(params).page(params[:page])
   end
 end

--- a/app/models/concerns/filterable.rb
+++ b/app/models/concerns/filterable.rb
@@ -9,15 +9,15 @@ module Filterable
     attr_reader :filter_scopes
 
     def filter_scope(name, *args)
-      scope name, *args
+      scope "filter_by_#{name}", *args
       filter_scopes << name
     end
 
     def filter_by(filtering_params)
       results = all
-      filtering_params.each do |filter_scope, filter_value|
+      filtering_params.slice(*filter_scopes).each do |filter_name, filter_value|
         filter_value = filter_value.select(&:present?) if filter_value.is_a?(Array)
-        results = results.public_send(filter_scope, filter_value) if filter_value.present?
+        results = results.public_send("filter_by_#{filter_name}", filter_value) if filter_value.present?
       end
       results
     end


### PR DESCRIPTION
A couple simple improvements:
1. whitelist filtering params in Filterable

instead of on a controller level. On a controller level additional whitelists may be applied when necessary.

2. use more meaningful scope names

e.g. `User.filter_by_country('Ireland')` instead of `User.country('Ireland')`. Can be debatable, but for me it makes more sense to have such clearly named scopes. I understand in your solution you deliberately made the opposite, from https://ifiwere.me/technology/2020/10/09/clean_index_filtering_rails.html:
>2. Removing ‘filter_by_’ prefix
>As a result of having a mechanism for automatic whitelisting of filtering scopes, it meant that we could remove the hardcoded prefix requirement for having to use `filter_by_<attribute_name>`.

I hope you can consider this again and make the final decision.